### PR TITLE
Scale citation bar heights

### DIFF
--- a/scripts/citations-static.html
+++ b/scripts/citations-static.html
@@ -248,13 +248,13 @@ a:hover {
         </div>
         <div class="chart-bars">
             <div class="bar-container">
-                <div class="bar highlight-pulse" style="height: 122.5px;" onmouseover="showTooltip(this, '7 citations in 2024')" onmouseout="hideTooltip(this)"></div>
+                <div class="bar highlight-pulse" style="height: 98px;" onmouseover="showTooltip(this, '7 citations in 2024')" onmouseout="hideTooltip(this)"></div>
                 <div class="bar-label">2024</div>
                 <div class="bar-value">7</div>
                 <div class="tooltip">7 citations in 2024</div>
             </div>
             <div class="bar-container">
-                <div class="bar" style="height: 157.5px;" onmouseover="showTooltip(this, '9 citations in 2025')" onmouseout="hideTooltip(this)"></div>
+                <div class="bar" style="height: 126px;" onmouseover="showTooltip(this, '9 citations in 2025')" onmouseout="hideTooltip(this)"></div>
                 <div class="bar-label">2025</div>
                 <div class="bar-value">9</div>
                 <div class="tooltip">9 citations in 2025</div>


### PR DESCRIPTION
Adjust bar heights in the research citation chart to correctly reflect values of 7 and 9 on a 10-max Y-axis.

---
<a href="https://cursor.com/background-agent?bcId=bc-75000081-cc22-49ad-92c0-d717f1eda430"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-75000081-cc22-49ad-92c0-d717f1eda430"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjust inline bar heights in `scripts/citations-static.html` so 2024 (7) and 2025 (9) scale correctly to a 10-max Y-axis.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b90ea23865973b059145543a45f343ce93383173. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->