### PR TITLE
Fix jekyll scss unit conversion error

### DIFF
--- a/_sass/_buttons.scss
+++ b/_sass/_buttons.scss
@@ -11,7 +11,7 @@
   padding: 0.85rem 1.75rem;
   color: $accent-color;
   font-family: $metadata-font-family;
-  font-size: clamp(0.65rem, 0.75rem + 0.2vw, 0.85rem);
+  font-size: clamp(0.65rem, unquote("calc(0.75rem + 0.2vw)"), 0.85rem);
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.25em;


### PR DESCRIPTION
Escape mixed-unit `calc()` expression in `font-size` to resolve Sass unit conversion error.

---
<a href="https://cursor.com/background-agent?bcId=bc-88fed936-69cd-4ba8-8aa6-9585f847d7bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-88fed936-69cd-4ba8-8aa6-9585f847d7bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

