### PR TITLE
Fix scss unit incompatibility error

### DIFF
--- a/_sass/_kinetic-theme.scss
+++ b/_sass/_kinetic-theme.scss
@@ -591,8 +591,8 @@ a {
    ========================================================================== */
 
 #main {
-  padding-top: clamp(6rem, 4.5rem + 2vw, 8.5rem); // Space for fixed navigation across viewports
-  scroll-padding-top: clamp(6rem, 4.5rem + 2vw, 8.5rem);
+  padding-top: clamp(6rem, unquote("calc(4.5rem + 2vw)"), 8.5rem); // Space for fixed navigation across viewports
+  scroll-padding-top: clamp(6rem, unquote("calc(4.5rem + 2vw)"), 8.5rem);
 
   @include breakpoint($medium) {
     padding-top: 8.5rem;


### PR DESCRIPTION
Fix Sass compilation error due to incompatible units in `clamp()` by unquoting the `calc()` expression.

---
<a href="https://cursor.com/background-agent?bcId=bc-59bcb4ba-f2c5-4f70-ac1e-49aab25d0e95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-59bcb4ba-f2c5-4f70-ac1e-49aab25d0e95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

